### PR TITLE
hv-tools: prefer kernel tree sources (PKG_SOURCE_URL) with wget fallback

### DIFF
--- a/utils/hv-tools/Makefile
+++ b/utils/hv-tools/Makefile
@@ -7,6 +7,8 @@ PKG_LICENSE:=GPL-2.0-only
 
 PKG_MAINTAINER:=Evgeniy Nikulov <nikulov@live.ru>
 
+PKG_BUILD_DIR := $(KERNEL_BUILD_DIR)/tools/hv
+
 include $(INCLUDE_DIR)/package.mk
 
 define Package/hv-tools
@@ -15,7 +17,7 @@ define Package/hv-tools
   SUBMENU:=Virtualization
   TITLE:=Hyper-V guest tools
   URL:=https://www.kernel.org
-  DEPENDS:=@(TARGET_x86||TARGET_x86_64) +kmod-hv-balloon +kmod-hv-kvp +kmod-hv-utils +kmod-hv-vmbus +libpthread
+  DEPENDS:=@(TARGET_x86||TARGET_x86_64) +libpthread
 endef
 
 define Package/hv-tools/description
@@ -25,21 +27,8 @@ define Package/hv-tools/description
 endef
 
 define Build/Prepare
-	$(INSTALL_DIR) $(PKG_BUILD_DIR)
-	wget -q -O $(PKG_BUILD_DIR)/hv_kvp_daemon.c \
-		'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/tools/hv/hv_kvp_daemon.c?h=v$(LINUX_VERSION)'
-	wget -q -O $(PKG_BUILD_DIR)/hv_vss_daemon.c \
-		'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/tools/hv/hv_vss_daemon.c?h=v$(LINUX_VERSION)'
-	wget -q -O $(PKG_BUILD_DIR)/hv_fcopy_uio_daemon.c \
-		'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/tools/hv/hv_fcopy_uio_daemon.c?h=v$(LINUX_VERSION)'
-	wget -q -O $(PKG_BUILD_DIR)/vmbus_bufring.h \
-		'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/tools/hv/vmbus_bufring.h?h=v$(LINUX_VERSION)'
-	wget -q -O $(PKG_BUILD_DIR)/vmbus_bufring.c \
-		'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/tools/hv/vmbus_bufring.c?h=v$(LINUX_VERSION)'
-	wget -q -O $(PKG_BUILD_DIR)/hv_get_dhcp_info.sh \
-		'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/tools/hv/hv_get_dhcp_info.sh?h=v$(LINUX_VERSION)'
-	wget -q -O $(PKG_BUILD_DIR)/hv_get_dns_info.sh \
-		'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/tools/hv/hv_get_dns_info.sh?h=v$(LINUX_VERSION)'
+	mkdir -p $(PKG_BUILD_DIR)
+	$(CP) $(LINUX_DIR)/tools/hv/* $(PKG_BUILD_DIR)/
 endef
 
 define Build/Compile


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @<github-user>
<sub>(You can find this by checking the history of the package `Makefile`.)</sub>

**Description:**
<!-- Briefly describe what this package does or what changes are introduced -->

---

## 🧪 Run Testing Details

- **OpenWrt Version:**
- **OpenWrt Target/Subtarget:**
- **OpenWrt Device:**

---

## ✅ Formalities

- [ ] I have reviewed the [CONTRIBUTING.md](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md) file for detailed contributing guidelines.

### If your PR contains a patch:

- [ ] It can be applied using `git am`
- [ ] It has been refreshed to avoid offsets, fuzzes, etc., using
  ```bash
  make package/<your-package>/refresh V=s
  ```
- [ ] It is structured in a way that it is potentially upstreamable
<sub>(e.g., subject line, commit description, etc.)</sub>
<sub>We must try to upstream patches to reduce maintenance burden.</sub>
